### PR TITLE
Remove try catch block that prevents usable errors

### DIFF
--- a/lib/src/jwt.dart
+++ b/lib/src/jwt.dart
@@ -22,7 +22,6 @@ class JWT {
     String issuer,
     String jwtId,
   }) {
-    try {
       final parts = token.split('.');
 
       Map<String, dynamic> header = jsonBase64.decode(base64Padded(parts[0]));
@@ -116,9 +115,6 @@ class JWT {
       } else {
         return JWT(payload);
       }
-    } catch (ex) {
-      throw JWTInvalidError('invalid token');
-    }
   }
 
   /// JSON Web Token


### PR DESCRIPTION
The try catch block that wrapped all other code in the verify method previously
catches all useful errors that are thrown, and instead throws the same error all
the time, which is not very useful.